### PR TITLE
Fix customer creation by removing mountpoints

### DIFF
--- a/backupctl/backupctl.py
+++ b/backupctl/backupctl.py
@@ -251,7 +251,7 @@ def new(hist, dirvish, pool, root, customer, vault=None, size=None, client=None)
         path = os.path.join(root, customer, vault)
     else:
         fs = os.path.join(pool, customer)
-        path = os.path.join(root, customer)
+        path = None
     fs_status = zfs.new_filesystem(fs, path, size)
     if fs_status:
         hist.add(customer, "create", vault, size)

--- a/backupctl/zfs.py
+++ b/backupctl/zfs.py
@@ -7,7 +7,7 @@ import subprocess
 logger = logging.getLogger(__name__)
 
 
-def new_filesystem(fs, path, size=None, compression=True):
+def new_filesystem(fs, path=None, size=None, compression=True):
     """Create a new zfs file system. The file system is automatically mounted
     according to the path property.
 
@@ -28,6 +28,8 @@ def new_filesystem(fs, path, size=None, compression=True):
         size = ["-o", "quota={0}".format(size)]
     else:
         size = []
+    if path is None:
+        path = "none"
 
     returncode, stdout, stderr = execute_cmd(
         ["zfs", "create", "-o", compression, "-o", "dedup=off"]


### PR DESCRIPTION


##### SUMMARY
Fix customer creation, customer groups do not need mountpoints.


##### ISSUE TYPE
 - Bugfix Pull Request



##### ZFS VERSION
<!--- Paste verbatim output from "modinfo zfs | grep -v ^parm" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful. -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
